### PR TITLE
Use shlex to split strings

### DIFF
--- a/vgkits/vanguard/__init__.py
+++ b/vgkits/vanguard/__init__.py
@@ -122,10 +122,11 @@ def calculateDataDir(*descendantDirs):
 def emulateInvocation(commandPattern, commandLookup):
     import sys
     import string
+    import shlex
     try:
         command = string.Template(commandPattern).substitute(commandLookup)
         print("Running '" + command + "'")
-        sys.argv = command.split()
+        sys.argv = shlex.split(command)
     except KeyError as e:
         raise RuntimeError("Invocation '" + commandPattern + "' missing value: " + str(e))
 

--- a/vgkits/vanguard/brainwash/__init__.py
+++ b/vgkits/vanguard/brainwash/__init__.py
@@ -116,6 +116,12 @@ def run(target=None, release=None, port=None, baud=1500000, erase=True, flash=Tr
                 path=path
             )
 
+            # locate target firmware
+            import pipes
+            flashLookup.update(
+                path=pipes.quote(flashLookup['path'])
+            )
+
             flashCommand = "esptool.py --port ${port} --baud ${baud} write_flash --flash_mode ${flash_mode} --flash_size ${flash_size} 0 ${path}"
             emulateInvocation(flashCommand, flashLookup)
             esptool.main()


### PR DESCRIPTION
Previous implementation assumed space could be used to split, but this doesn't work for backslash-escaped filenames with spaces in.